### PR TITLE
Fix NULL check against lcap data

### DIFF
--- a/jailme.c
+++ b/jailme.c
@@ -70,7 +70,7 @@ main(int argc, char *argv[])
 	if (chdir("/") == -1)
 		err(1, "chdir(): /");
 	lcap = login_getpwclass(jusername);
-	if (lcap = NULL)
+	if (lcap == NULL)
 		err(1, "getpwclass: %s", jusername);
 	ngroups = NGROUPS;
 	if (getgrouplist(jusername->pw_name, jusername->pw_gid, groups, &ngroups) != 0)	


### PR DESCRIPTION
Fix NULL check against lcap data from the jail which was actually setting lcap to NULL.  This lines up with similar code in jexec(8).
