### PR TITLE
Allow the usage of jail names in addition to jids.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 all: jailme
 
 jailme: jailme.c
-	${CC} -lutil -o jailme jailme.c
+	${CC} -lutil -ljail -o jailme jailme.c
 
 install: jailme
 	install -o root -g wheel -m 4751 jailme /usr/local/sbin


### PR DESCRIPTION
Uses jail_getid() from libjail.  Also provide more specific output when username/UID mapping into the jail fails.